### PR TITLE
Add timestamp when storing operation

### DIFF
--- a/src/server/db/pg.coffee
+++ b/src/server/db/pg.coffee
@@ -69,7 +69,7 @@ module.exports = PgDb = (options) ->
         v int4 NOT NULL,
         op text NOT NULL,
         meta text NOT NULL,
-        created_at timestamp(6),
+        created_at timestamp(6) NOT NULL,
         CONSTRAINT operations_pkey PRIMARY KEY (doc, v)
       );
     """


### PR DESCRIPTION
First part of the fix. Second part (once the migration on TC and this fix have been deployed) will be to modify the deleteOps method to delete only operations older than a certain time.
