### PR TITLE
stop using our browserchannel fork, switch back to upstream

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "uglify-js": "~1",
     "request": ">= 2.1.1 < 2.16.0",
     "coffee-script": "*",
-    "browserchannel": "git://github.com/conversation/node-browserchannel.git",
+    "browserchannel": ">= 0.4.1",
     "hat": "*"
   },
   "devDependencies": {


### PR DESCRIPTION
- Our fork had a single change to ensure \u2028 and \u2029 characters
  were escaped before being snt over the wire
- Our changes were accepted upstream 2 years ago ( [1] and [2] ) so there's
  no need to maintain the fork

[1] https://github.com/josephg/node-browserchannel/commit/a7b1f37510c026acfa8e704e48319f2c0ad8c511
[2] https://github.com/josephg/node-browserchannel/commit/d9d4dc56f63af02b72bfcd30c7c5069f5a1fdee3
