### PR TITLE
Expand the REST API to allow a specific document version to be returned

### DIFF
--- a/src/server/db/pg.coffee
+++ b/src/server/db/pg.coffee
@@ -120,6 +120,28 @@ module.exports = PgDb = (options) ->
       else
         callback? error?.message
 
+  @getSnapshotLessThanOrEqualTo = (docName, v, callback) ->
+    sql = """
+      SELECT *
+      FROM #{snapshot_table}
+      WHERE "doc" = $1 AND "v" <= $2
+      ORDER BY "v" DESC
+      LIMIT 1
+    """
+    client.query sql, [docName, v], (error, result) ->
+      if !error? and result.rows.length > 0
+        row = result.rows[0]
+        data =
+          v:        row.v
+          snapshot: JSON.parse(row.snapshot)
+          meta:     JSON.parse(row.meta)
+          type:     row.type
+        callback? null, data
+      else if !error?
+        callback? "Document does not exist"
+      else
+        callback? error?.message
+
   @getSnapshot = (docName, callback) ->
     sql = """
       SELECT *

--- a/src/server/db/pg.coffee
+++ b/src/server/db/pg.coffee
@@ -120,28 +120,6 @@ module.exports = PgDb = (options) ->
       else
         callback? error?.message
 
-  @getSnapshotLessThanOrEqualTo = (docName, v, callback) ->
-    sql = """
-      SELECT *
-      FROM #{snapshot_table}
-      WHERE "doc" = $1 AND "v" <= $2
-      ORDER BY "v" DESC
-      LIMIT 1
-    """
-    client.query sql, [docName, v], (error, result) ->
-      if !error? and result.rows.length > 0
-        row = result.rows[0]
-        data =
-          v:        row.v
-          snapshot: JSON.parse(row.snapshot)
-          meta:     JSON.parse(row.meta)
-          type:     row.type
-        callback? null, data
-      else if !error?
-        callback? "Document does not exist"
-      else
-        callback? error?.message
-
   @getSnapshot = (docName, callback) ->
     sql = """
       SELECT *

--- a/src/server/model.coffee
+++ b/src/server/model.coffee
@@ -543,7 +543,6 @@ module.exports = Model = (db, options) ->
         return callback? error if error
 
         docTemplate = {v: 0, type: type, snapshot: "", meta: null}
-        results = []
 
         try
           for op in ops

--- a/src/server/model.coffee
+++ b/src/server/model.coffee
@@ -534,10 +534,17 @@ module.exports = Model = (db, options) ->
       if error
         callback error, null
         return
+
+      type = types[latestDoc.type]
+      unless type
+        console.warn "Type '#{data.type}' missing"
+        callback "Type not found", null
+        return
+
       requiredOpCount = v - latestDoc.v
 
       if requiredOpCount == 0
-        doc = {type: latestDoc.type, snapshot: latestDoc.snapshot, v: latestDoc.v, meta: latestDoc.meta}
+        doc = {type: type, snapshot: latestDoc.snapshot, v: latestDoc.v, meta: latestDoc.meta}
         callback null, doc
         return
 
@@ -551,11 +558,6 @@ module.exports = Model = (db, options) ->
           return
 
         doc = {snapshot: latestDoc.snapshot}
-        type = types[latestDoc.type]
-        unless type
-          console.warn "Type '#{data.type}' missing"
-          callback "Type not found", null
-          return
 
         doc.type = type
         for op in ops

--- a/src/server/rest.coffee
+++ b/src/server/rest.coffee
@@ -105,7 +105,7 @@ matchDocNameWithVersions = (urlString, base) ->
 #   10
 #   > matchVersion 'http://example.com/'
 #   10
-#   > matchDocName 'hello'
+#   > matchVersion 'hello'
 #   undefined
 matchVersion = (urlString) ->
   urlParts = url.parse urlString

--- a/src/server/rest.coffee
+++ b/src/server/rest.coffee
@@ -20,7 +20,7 @@ sendError = (res, message, head = false) ->
       send403 res, ""
     else
       send403 res
-  else if message == 'Document does not exist'
+  else if message == 'Document does not exist' || 'operations missing in DB'
     if head
       send404 res, ""
     else

--- a/src/server/useragent.coffee
+++ b/src/server/useragent.coffee
@@ -79,6 +79,10 @@ module.exports = (model, options) ->
       @doAuth {docName}, 'get version', callback, ->
         model.getVersions docName, v, callback
 
+    getSnapshotVersion: (docName, version, callback) ->
+      @doAuth {docName}, 'get snapshot', callback, ->
+        model.getSnapshotVersion docName, version, callback
+
     create: (docName, type, meta, callback) ->
       # We don't check that types[type.name] == type. That might be important at some point.
       type = types[type] if typeof type == 'string'

--- a/test/model.coffee
+++ b/test/model.coffee
@@ -1166,3 +1166,27 @@ exports['integration'] = testCase
           test.strictEqual v, 1
           test.done()
 
+  'getSnapshotVersion for a doc returns a snapshot for that version': (test) ->
+    name = newDocName()
+
+    @model.create name, types.text, (error) =>
+      test.equal error, null
+
+      applyOps @model, name, 0, [
+        [{ p: 0, i: 'Hi' }],
+        [{ p: 2, i: ' mum' }],
+        [{ p: 1, d: 'i' }],
+        [{ p: 1, i: 'ello' }],
+      ], (error, data) =>
+        test.equal error, null
+
+        @model.getSnapshotVersion name, 1, (error, data) =>
+          test.deepEqual error, null
+          test.deepEqual data.snapshot, "Hi mum"
+          test.deepEqual data.v, 1
+
+          @model.getSnapshotVersion name, 3, (error, data) ->
+            test.deepEqual error, null
+            test.deepEqual data.snapshot, "Hello mum"
+            test.deepEqual data.v, 3
+            test.done()


### PR DESCRIPTION
This is is no way ready to be merged or reviewed! I'm just hacking around :eyes: 

The existing REST API allows the latest version of a document to be requested using:

```
GET /doc/123abc
```

This expands the API to allow a specific version to be requested:

```
GET /doc/123abc?v=10
```

It works, however the current implementation is inefficient. It relies on the DB containing every operation from 0 to the requested version, then applying them in order. This has a few implications:
1. Sequential requests for versions 10 and 11 will fetch all operations from 1-10, apply them and return version 10, then fetch all operations from 1-11, apply them and return version 11. Imagine requesting version 3000 and 3001.
2. If any operations are missing (like for all our drafts) then the request will fail

One possible improvement would be to look for the highest snapshot version that is less than the requested version, then only fetch the remaining ops to the requested version (probably < 20 ops). That will require changes to the persistence layer though, so I haven't tried it yet.

To test this, modify `packages.json` in the `tc-share`  repo to refer to this branch (`git://github.com/conversation/ShareJS.git#snapshot-versions`) and then run `npm install`
