### PR TITLE
Expand the REST API to return all snapshots for a specific document

### DIFF
--- a/src/server/db/pg.coffee
+++ b/src/server/db/pg.coffee
@@ -146,6 +146,28 @@ module.exports = PgDb = (options) ->
       else
         callback? error?.message
 
+  @getSnapshots = (docName,callback) ->
+    sql = """
+      SELECT *
+      FROM #{snapshot_table}
+      WHERE "doc" = $1
+      ORDER BY "v" ASC
+    """
+    client.query sql, [docName], (error, result) ->
+      if !error? and result.rows.length > 0
+        data = result.rows.map (row) ->
+          return {
+            v:        row.v,
+            snapshot: row.snapshot_json,
+            meta:     row.meta_json,
+            type:     row.type
+          }
+        callback? null, data
+      else if !error?
+        callback? "Document does not exist"
+      else
+        callback? error?.message
+
   @writeSnapshot = (docName, docData, dbMeta, callback) =>
     sql = if options.keep_snapshots
       """

--- a/src/server/model.coffee
+++ b/src/server/model.coffee
@@ -486,6 +486,13 @@ module.exports = Model = (db, options) ->
     load docName, (error, doc) ->
       callback error, if doc then {v:doc.v, type:doc.type, snapshot:doc.snapshot, meta:doc.meta}
 
+  @getSnapshots = (docname, callback) ->
+    db.getSnapshots docname, (error, snapshots) ->
+      if error
+        callback error, null
+        return
+      callback null, snapshots
+
   # Gets the latest version # of the document.
   # getVersion(docName, callback)
   # callback is called with (error, version).

--- a/src/server/useragent.coffee
+++ b/src/server/useragent.coffee
@@ -74,6 +74,10 @@ module.exports = (model, options) ->
     getSnapshot: (docName, callback) ->
       @doAuth {docName}, 'get snapshot', callback, ->
         model.getSnapshot docName, callback
+
+    getSnapshots: (docName, callback) ->
+      @doAuth {docName}, 'get snapshot', callback, ->
+        model.getSnapshots docName, callback
     
     create: (docName, type, meta, callback) ->
       # We don't check that types[type.name] == type. That might be important at some point.


### PR DESCRIPTION
The existing REST API allows the latest version of a document to be requested using:

`GET /doc/123abc`

This expands the API to allow all snapshots to be retrieved as JSON:

`GET /doc/123abc/snapshots`

It works, but probably needs a bit of polish.

The tc app currently directly accesses the sharejs db tables to fetch this data and display it on the history scrubber. Once this endpoint is available, we can change tc to fetch the snapshots via the API. That removes the DB-level coupling, and we'll be free to move all sharejs data into a dedicated DB.

To test this, modify `packages.json` in the `tc-share`  repo to refer to this branch (`git://github.com/conversation/ShareJS.git#get-snapshots`) and then run `npm install`. Then start sharejs (`coffee app.coffee`) and use curl to fetch `/doc/123abc/snapshots`.