### PR TITLE
write snapshop and op data to JSON+TEXT cols

### DIFF
--- a/src/server/db/pg.coffee
+++ b/src/server/db/pg.coffee
@@ -87,10 +87,10 @@ module.exports = PgDb = (options) ->
 
   @create = (docName, docData, callback) ->
     sql = """
-      INSERT INTO #{snapshot_table} ("doc", "v", "snapshot", "meta", "type", "created_at")
-        VALUES ($1, $2, $3, $4, $5, now() at time zone 'UTC')
+      INSERT INTO #{snapshot_table} ("doc", "v", "snapshot", "snapshot_json", "meta", "meta_json", "type", "created_at")
+        VALUES ($1, $2, $3, ($4)::json, $5, $6, $7, now() at time zone 'UTC')
     """
-    values = [docName, docData.v, JSON.stringify(docData.snapshot), JSON.stringify(docData.meta), docData.type]
+    values = [docName, docData.v, JSON.stringify(docData.snapshot), JSON.stringify(docData.snapshot), JSON.stringify(docData.meta), docData.meta, docData.type]
     client.query sql, values, (error, result) ->
       if !error?
         callback?()
@@ -149,16 +149,16 @@ module.exports = PgDb = (options) ->
   @writeSnapshot = (docName, docData, dbMeta, callback) =>
     sql = if options.keep_snapshots
       """
-        INSERT INTO #{snapshot_table} ("doc", "v", "snapshot", "meta", "type", "created_at")
-        VALUES ($1, $2, $3, $4, $5, now() at time zone 'UTC')
+        INSERT INTO #{snapshot_table} ("doc", "v", "snapshot", "snapshot_json", "meta", "meta_json", "type", "created_at")
+        VALUES ($1, $2, $3, ($4)::json, $5, $6, $7, now() at time zone 'UTC')
       """
     else
       """
         UPDATE #{snapshot_table}
-        SET "v" = $2, "snapshot" = $3, "meta" = $4
+        SET "v" = $2, "snapshot" = $3, snapshot_json = $4, "meta" = $5, "meta_json" = $6
         WHERE "doc" = $1
       """
-    values = [docName, docData.v, JSON.stringify(docData.snapshot), JSON.stringify(docData.meta), docData.type]
+    values = [docName, docData.v, JSON.stringify(docData.snapshot), JSON.stringify(docData.snapshot), JSON.stringify(docData.meta), docData.meta, docData.type]
     client.query sql, values, (error, result) =>
       if !error?
         if options.keep_operations
@@ -207,10 +207,10 @@ module.exports = PgDb = (options) ->
 
   @writeOp = (docName, opData, callback) ->
     sql = """
-      INSERT INTO #{operations_table} ("doc", "op", "v", "meta", "created_at")
-        VALUES ($1, $2, $3, $4, now() at time zone 'UTC')
+      INSERT INTO #{operations_table} ("doc", "op", "op_json", "v", "meta", "meta_json", "created_at")
+        VALUES ($1, $2, ($3)::json, $4, $5, $6, now() at time zone 'UTC')
     """
-    values = [docName, JSON.stringify(opData.op), opData.v, JSON.stringify(opData.meta)]
+    values = [docName, JSON.stringify(opData.op), JSON.stringify(opData.op), opData.v, JSON.stringify(opData.meta), opData.meta]
     client.query sql, values, (error, result) ->
       if !error?
         callback?()


### PR DESCRIPTION
* continue to read from the TEXT column for now
* once the JSON column is fully populated there'll be a second commit
  that reads from the JSON col
* node-postgres can automatically handle converting JS objects into JSON
  when inserting, but unfortunately it doesn't convert JS arrays into
  JSON arrays. To work around that we have to manually call
  JSON.stringify when inserting ops and snapshots, and use ::json to
  convert it inside postgres