### PR TITLE
Add versions endpoint

### DIFF
--- a/src/server/model.coffee
+++ b/src/server/model.coffee
@@ -486,12 +486,13 @@ module.exports = Model = (db, options) ->
     load docName, (error, doc) ->
       callback error, if doc then {v:doc.v, type:doc.type, snapshot:doc.snapshot, meta:doc.meta}
 
+  # Gets the snapshots for the specified document.
   @getSnapshots = (docname, callback) ->
     db.getSnapshots docname, (error, snapshots) ->
       if error
-        callback error, null
-        return
-      callback null, snapshots
+        callback? error
+      else
+        callback? null, snapshots
 
   # Gets the latest version # of the document.
   # getVersion(docName, callback)

--- a/src/server/model.coffee
+++ b/src/server/model.coffee
@@ -512,13 +512,17 @@ module.exports = Model = (db, options) ->
         docTemplate = {v: 0, type: type, snapshot: "", meta: null}
         results = []
 
-        for op in ops
-          docTemplate.v = op.v + 1
-          docTemplate.snapshot = type.apply(docTemplate.snapshot, op.op)
-          docTemplate.meta = op.meta
-          results.push(Object.assign({}, docTemplate)) if (docTemplate.v % n is 0)
+        try
+          for op in ops
+            docTemplate.v = op.v + 1
+            docTemplate.snapshot = type.apply(docTemplate.snapshot, op.op)
+            docTemplate.meta = op.meta
+            results.push(Object.assign({}, docTemplate)) if (docTemplate.v % n is 0)
 
-        callback? null, results
+          callback? null, results
+        catch e
+          console.error "Op data invalid for #{docName}: #{e.stack}"
+          callback? 'Op data invalid'
 
   # Gets the latest version # of the document.
   # getVersion(docName, callback)

--- a/src/server/rest.coffee
+++ b/src/server/rest.coffee
@@ -32,7 +32,7 @@ sendError = (res, message, head = false) ->
       res.end "Error: #{message}\n"
     else
       res.writeHead 500, {}
-      res.end ""
+      res.end "Error: #{message}\n"
 
 send400 = (res, message) ->
   res.writeHead 400, {'Content-Type': 'text/plain'}

--- a/src/server/rest.coffee
+++ b/src/server/rest.coffee
@@ -173,17 +173,13 @@ getDocumentSnapshots = (req, res, client) ->
 # GET returns the document versions.
 getDocumentVersions = (req, res, client) ->
   client.getVersions req.params.name, req.params.every, (error, docs) ->
-    if docs && docs.length > 0
+    return sendError res, error if error
+
+    if docs.length > 0
       res.setHeader 'X-OT-Type', docs[0].type.name
-      if req.method == "HEAD"
-        send200 res, ""
-      else
-        sendJSON res, docs
+      sendJSON res, docs
     else
-      if req.method == "HEAD"
-        sendError res, error, true
-      else
-        sendError res, error
+      sendJSON res, []
 
 # Put is used to create a document. The contents are a JSON object with {type:TYPENAME, meta:{...}}
 putDocument = (req, res, client) ->

--- a/src/server/useragent.coffee
+++ b/src/server/useragent.coffee
@@ -21,7 +21,7 @@ module.exports = (model, options) ->
       @headers = data.headers
       @remoteAddress = data.remoteAddress
       @authentication = data.authentication
-      
+
       # This is a map from docName -> listener function
       @listeners = {}
 
@@ -46,7 +46,7 @@ module.exports = (model, options) ->
       action.type = switch name
         when 'connect' then 'connect'
         when 'create' then 'create'
-        when 'get snapshot', 'get ops', 'open' then 'read'
+        when 'get snapshot', 'get version', 'get ops', 'open' then 'read'
         when 'submit op' then 'update'
         when 'submit meta' then 'update'
         when 'delete' then 'delete'
@@ -78,7 +78,11 @@ module.exports = (model, options) ->
     getSnapshots: (docName, callback) ->
       @doAuth {docName}, 'get snapshot', callback, ->
         model.getSnapshots docName, callback
-    
+
+    getVersions: (docName, v, callback) ->
+      @doAuth {docName}, 'get version', callback, ->
+        model.getVersions docName, v, callback
+
     create: (docName, type, meta, callback) ->
       # We don't check that types[type.name] == type. That might be important at some point.
       type = types[type] if typeof type == 'string'
@@ -112,7 +116,7 @@ module.exports = (model, options) ->
     delete: (docName, callback) ->
       @doAuth {docName}, 'delete', callback, =>
         model.delete docName, callback
-    
+
     # Open the named document for reading. Just like model.listen, version is optional.
     listen: (docName, version, listener, callback) ->
       authOps = if version?


### PR DESCRIPTION
I added a `/versions` endpoint which allows a client to request all versions of a document, in steps of a specified size.

The reason for adding this endpoint is that it will allow us to remove a whole lot of snapshots from the production database. They are currently taking up ~50GB, and it would be great if we can prune old snapshots.

However, the history slider requires a list of versions to scrub through. We used to get the versions straight from the snapshots, but now we can generate them dynamically. ✨ 

## How to test

- Update the `share` dependency in the `package.json` file for the `tc-share` app to: `"share": "git://github.com/conversation/ShareJS.git#c6e804d"`.

  For development I used `npm ln`, but YMMV.

- Fire up the server with `npm start`

-  Curl the new endpoint with a document ID: `curl "http://localhost:9000/doc/xyz/versions?every=5"`
