### PR TITLE
SQL in both of the keep_snapshot code paths must use same number of variables

### DIFF
--- a/src/server/db/pg.coffee
+++ b/src/server/db/pg.coffee
@@ -176,7 +176,7 @@ module.exports = PgDb = (options) ->
     else
       """
         UPDATE #{snapshot_table}
-        SET "v" = $2, "snapshot" = ($3)::jsonb, "meta" = $4
+        SET "v" = $2, "snapshot" = ($3)::jsonb, "meta" = $4, "type" = $5
         WHERE "doc" = $1
       """
     values = [docName, docData.v, JSON.stringify(docData.snapshot), docData.meta, docData.type]


### PR DESCRIPTION
`keep_snapshots` was an option we introduced to our fork, and we've now decided to stop using it - the data storage requirements are significant and we don't need them any more.

We plan to return to the standard sharejs behaviour of only keeping a single snapshot per document to optimise the common case of needing the latest version of a document.

I'm not sure how this discrepancy was introduced, but we haven't noticed before now because we've had keep_snapshots enabled for as long as we've used sharejs. I tested setting `keep_snapshots: false` locally in preparation for the upcoming changes and found the issue.

Once this has been deployed, we may want to consider reverting the original change in our fork to remove the `keep_snapshots` option all together. There's no use maintaining it in our fork if it's unused.