### PR TITLE
ShareJS Cleanup 1/2: Revert "Merge pull request #5 from conversation/get-snapshots"

### DIFF
--- a/src/server/db/pg.coffee
+++ b/src/server/db/pg.coffee
@@ -145,28 +145,6 @@ module.exports = PgDb = (options) ->
       else
         callback? error?.message
 
-  @getSnapshots = (docName,callback) ->
-    sql = """
-      SELECT *
-      FROM #{snapshot_table}
-      WHERE "doc" = $1
-      ORDER BY "v" ASC
-    """
-    client.query sql, [docName], (error, result) ->
-      if !error? and result.rows.length > 0
-        data = result.rows.map (row) ->
-          return {
-            v:        row.v,
-            snapshot: row.snapshot,
-            meta:     row.meta,
-            type:     row.type
-          }
-        callback? null, data
-      else if !error?
-        callback? "Document does not exist"
-      else
-        callback? error?.message
-
   @writeSnapshot = (docName, docData, dbMeta, callback) =>
     sql = if options.keep_snapshots
       """

--- a/src/server/model.coffee
+++ b/src/server/model.coffee
@@ -486,14 +486,6 @@ module.exports = Model = (db, options) ->
     load docName, (error, doc) ->
       callback error, if doc then {v:doc.v, type:doc.type, snapshot:doc.snapshot, meta:doc.meta}
 
-  # Gets the snapshots for the specified document.
-  @getSnapshots = (docname, callback) ->
-    db.getSnapshots docname, (error, snapshots) ->
-      if error
-        callback? error
-      else
-        callback? null, snapshots
-
   # Gets every version of the specified document, in intervals of `n`. This
   # function doesn't use snapshot data, it rebuilds the document versions from
   # the operations.

--- a/src/server/useragent.coffee
+++ b/src/server/useragent.coffee
@@ -75,10 +75,6 @@ module.exports = (model, options) ->
       @doAuth {docName}, 'get snapshot', callback, ->
         model.getSnapshot docName, callback
 
-    getSnapshots: (docName, callback) ->
-      @doAuth {docName}, 'get snapshot', callback, ->
-        model.getSnapshots docName, callback
-
     getVersions: (docName, v, callback) ->
       @doAuth {docName}, 'get version', callback, ->
         model.getVersions docName, v, callback


### PR DESCRIPTION
This additional REST endpoint was added to our sharejs fork (in #5) as a way to fetch data for the history slider on drafts#edit.

We've since added a `/versions` REST endpoint and have switched to that for the same purpose. In the interests of reducing the delta between our fork and upstream, let's remove the unused endpoint.