### PR TITLE
Lock dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "ws": "*",
     "connect": "<3.x",
     "request": ">= 2.1.1",
-    "coffee-script": "<1.7",
+    "coffee-script": "1.6.2",
     "hat": "*"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "express": "~ 3.x",
     "optimist": ">= 0.2.4",
     "nodeunit": "*",
-    "shelljs": "*",
+    "shelljs": "0.1.4",
     "uglify-js": "~1",
     "websocket": "*"
   },


### PR DESCRIPTION
@RohanM and I discovered that if you lock `coffee-script` (to get consistent code generation) and `shelljs`  (so it actually compiles in the first place). We can actually start developing on this fork.