### PR TITLE
Ensure that coffeescript files get compiled to JS when required

### DIFF
--- a/Cakefile
+++ b/Cakefile
@@ -121,7 +121,7 @@ task 'bump', 'Increase the patch level of the version, -V is optional', (options
   if exec("git status --porcelain").output.match /^ M /m
     throw new Error "git status must be clean"
 
-  for file in ["package.json", "src/index.coffee", "src/client/web-prelude.coffee"]
+  for file in ["package.json", "src/index.js", "src/client/web-prelude.coffee"]
     sed '-i', oldVersion, version, file
 
   invoke "webclient"

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -1,5 +1,0 @@
-exports.server = require './server'
-exports.client = require './client'
-exports.types = require './types'
-
-exports.version = '0.6.3'

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,7 @@
+require("coffee-script/register");
+
+exports.server = require('./server');
+exports.client = require('./client');
+exports.types = require('./types');
+
+exports.version = '0.6.3';


### PR DESCRIPTION
After coffee-script 1.7.x, you must register your coffeescript files for compilation, or they won't be compiled to JS.