### PR TITLE
Improve documentation to make it easier to support websockets

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ There are two ways to run a sharejs server:
     var connect = require('connect'),
         sharejs = require('share').server;
 
-    var server = connect(
+    var app = connect(
           connect.logger(),
           connect.static(__dirname + '/my_html_files')
         );
@@ -84,7 +84,7 @@ There are two ways to run a sharejs server:
     var options = {db: {type: 'none'}}; // See docs for options. {type: 'redis'} to enable persistance.
 
     // Attach the sharejs REST and Socket.io interfaces to the server
-    sharejs.attach(server, options);
+    server = sharejs.attach(app, options);
 
     server.listen(8000);
     console.log('Server running at http://127.0.0.1:8000/');

--- a/bin/exampleserver
+++ b/bin/exampleserver
@@ -22,6 +22,7 @@ app.use(express.static(__dirname + '/../examples'));
 var options = {
   db: {type: 'none'},
   browserChannel: {cors: '*'},
+  websocket: {prefix: '/websocket'},
   auth: function(client, action) {
     // This auth handler rejects any ops bound for docs starting with 'readonly'.
     if (action.name === 'submit op' && action.docName.match(/^readonly/)) {

--- a/bin/exampleserver
+++ b/bin/exampleserver
@@ -16,8 +16,8 @@ var argv = require('optimist').
   alias('p', 'port').
   argv;
 
-var server = express();
-server.use(express.static(__dirname + '/../examples'));
+var app = express();
+app.use(express.static(__dirname + '/../examples'));
 
 var options = {
   db: {type: 'none'},
@@ -44,27 +44,27 @@ console.log("Options: ", options);
 var port = argv.p;
 
 // Attach the sharejs REST and Socket.io interfaces to the server
-sharejs.server.attach(server, options);
+var server = sharejs.server.attach(app, options);
 
 var renderer = require('../examples/_static');
-server.get('/static/:docName', function(req, res, next) {
+app.get('/static/:docName', function(req, res, next) {
   var docName;
   docName = req.params.docName;
-  renderer(docName, server.model, res, next);
+  renderer(docName, app.model, res, next);
 });
 
 var wiki = require('../examples/_wiki');
-server.get('/wiki/?', function(req, res, next) {
+app.get('/wiki/?', function(req, res, next) {
   res.writeHead(301, {location: '/wiki/Main'});
   res.end();
 });
-server.get('/wiki/:docName', function(req, res, next) {
+app.get('/wiki/:docName', function(req, res, next) {
   var docName;
   docName = req.params.docName;
-  wiki(docName, server.model, res, next);
+  wiki(docName, app.model, res, next);
 });
 
-server.get('/pad/?', function(req, res, next) {
+app.get('/pad/?', function(req, res, next) {
   var docName;
   docName = hat();
   res.writeHead(303, {location: '/pad/pad.html#' + docName});
@@ -72,7 +72,7 @@ server.get('/pad/?', function(req, res, next) {
   res.end();
 });
 
-server.get('/?', function(req, res, next) {
+app.get('/?', function(req, res, next) {
   res.writeHead(302, {location: '/index.html'});
   res.end();
 });

--- a/bin/options.js
+++ b/bin/options.js
@@ -77,6 +77,9 @@ module.exports = {
   // Browserchannel server options. Set browserChannel:null to disable browserchannel.
   browserChannel: {},
 
+  // Websocket server options. Set websocket:null to disable websocket support.
+  websocket: {},
+
 	// Authentication code to test if clients are allowed to perform different actions.
 	// See documentation for details.
 	//auth: function(client, action) {

--- a/src/server/index.coffee
+++ b/src/server/index.coffee
@@ -31,6 +31,14 @@ create.createModel = createModel = (options) ->
 # defaults will be provided.
 #
 # Set options.rest == null or options.socketio == null to turn off that frontend.
+#
+# This method always returns a http.Server, which should be used to listen
+#
+# eg.
+#   var app = express();
+#   var server = sharejs.server.attach(app);
+#   server.listen(port);
+#
 create.attach = attach = (server, options, model = createModel(options)) ->
   options ?= {}
   options.staticpath ?= '/share'
@@ -60,4 +68,3 @@ create.attach = attach = (server, options, model = createModel(options)) ->
   websocket.attach(server, createAgent, options.websocket or {}) if options.websocket?
 
   server
-


### PR DESCRIPTION
The docs were previously a bit misleading, because they encouraged you to listen with express/connect, when this method does not work with websockets. You must listen with the `http.Server` returned by the `sharejs.attach` method for websockets to work.