### PR TITLE
Fix auto table creation

### DIFF
--- a/src/server/db/pg.coffee
+++ b/src/server/db/pg.coffee
@@ -53,7 +53,7 @@ module.exports = PgDb = (options) ->
     console.warn 'Creating postgresql database tables'
 
     sql = """
-      CREATE SCHEMA #{options.schema};
+      CREATE SCHEMA IF NOT EXISTS #{options.schema};
 
       CREATE TABLE #{snapshot_table} (
         doc text NOT NULL,


### PR DESCRIPTION
This is assuming that the schema doesn't already exist, which in our use case is not true, because we just use the public schema.

In the case where you do configure sharejs to use the public schema this would previously error as it tried to create it again.

We just want to create the schema if it doesn't already exist.