### PR TITLE
TC-382 Fix memory leak from not handling defunct websocket clients correctly

### DIFF
--- a/src/server/websocket.coffee
+++ b/src/server/websocket.coffee
@@ -11,6 +11,7 @@ wrapSession = (conn) ->
   wrapper.send = (response) ->
     conn.send JSON.stringify response if wrapper.ready()
   wrapper.ready = -> conn.readyState is 1
+  conn.on 'close', -> wrapper.emit 'close'
   conn.on 'message', (data) ->
     msg = JSON.parse data
 


### PR DESCRIPTION
If we don't emit `'close'` to the wrapper, it will never be handled in the [`sessionHandler`](https://github.com/conversation/ShareJS/blob/master/src/server/session.coffee#L351), so the event listeners on `agent` keep a reference to the event emitter wrapper indefinitely.

This should fix the memory leak we're currently seeing with websocket clients.