### PR TITLE
TC-394 Track websocket stats

### DIFF
--- a/bin/exampleserver
+++ b/bin/exampleserver
@@ -22,7 +22,12 @@ app.use(express.static(__dirname + '/../examples'));
 var options = {
   db: {type: 'none'},
   browserChannel: {cors: '*'},
-  websocket: {prefix: '/websocket'},
+  websocket: {
+    prefix: '/websocket',
+    trackStats: function(stats) {
+      console.log("Tracking stats:", JSON.stringify(stats));
+    }
+  },
   auth: function(client, action) {
     // This auth handler rejects any ops bound for docs starting with 'readonly'.
     if (action.name === 'submit op' && action.docName.match(/^readonly/)) {

--- a/src/server/websocket.coffee
+++ b/src/server/websocket.coffee
@@ -4,6 +4,8 @@ WebSocketServer = require('ws').Server
 
 sessionHandler = require('./session').handler
 
+STATISTICS_INTERVAL = 10000 # 10 seconds
+
 wrapSession = (conn) ->
   wrapper = new EventEmitter
   wrapper.abort = -> conn.close()
@@ -34,3 +36,9 @@ exports.attach = (server, createAgent, options) ->
   options.prefix or= '/websocket'
   wss = new WebSocketServer {server: server, path: options.prefix, headers: options.headers}
   wss.on 'connection', (conn) -> sessionHandler wrapSession(conn), createAgent
+
+  if !!options.trackStats
+    setInterval ->
+      options.trackStats
+        activeWebsocketConnections: wss.clients.length
+    , STATISTICS_INTERVAL


### PR DESCRIPTION
Adds a really basic stats tracking callback to websocket server, so we can keep an eye on active websocket connections in datadog.