### PR TITLE
Listen to input in addition to other events in textarea client

### DIFF
--- a/src/client/textarea.coffee
+++ b/src/client/textarea.coffee
@@ -61,7 +61,7 @@ window.sharejs.extendDoc 'attach_textarea', (elem) ->
         prevvalue = elem.value
         applyChange doc, doc.getText(), elem.value.replace /\r\n/g, '\n'
 
-  for event in ['textInput', 'keydown', 'keyup', 'select', 'cut', 'paste']
+  for event in ['input', 'textInput', 'keydown', 'keyup', 'select', 'cut', 'paste']
     if elem.addEventListener
       elem.addEventListener event, genOp, false
     else
@@ -71,7 +71,7 @@ window.sharejs.extendDoc 'attach_textarea', (elem) ->
     @removeListener 'insert', insert_listener
     @removeListener 'delete', delete_listener
 
-    for event in ['textInput', 'keydown', 'keyup', 'select', 'cut', 'paste']
+    for event in ['input', 'textInput', 'keydown', 'keyup', 'select', 'cut', 'paste']
       if elem.removeEventListener
         elem.removeEventListener event, genOp, false
       else

--- a/webclient/textarea.js
+++ b/webclient/textarea.js
@@ -76,7 +76,7 @@
         }
       });
     };
-    _ref = ['textInput', 'keydown', 'keyup', 'select', 'cut', 'paste'];
+    _ref = ['input', 'textInput', 'keydown', 'keyup', 'select', 'cut', 'paste'];
     for (_i = 0, _len = _ref.length; _i < _len; _i++) {
       event = _ref[_i];
       if (elem.addEventListener) {
@@ -90,7 +90,7 @@
         var _j, _len1, _ref1, _results;
         _this.removeListener('insert', insert_listener);
         _this.removeListener('delete', delete_listener);
-        _ref1 = ['textInput', 'keydown', 'keyup', 'select', 'cut', 'paste'];
+        _ref1 = ['input', 'textInput', 'keydown', 'keyup', 'select', 'cut', 'paste'];
         _results = [];
         for (_j = 0, _len1 = _ref1.length; _j < _len1; _j++) {
           event = _ref1[_j];


### PR DESCRIPTION
I suspect the "textInput" was a typo/mistake in the original code, as this is a jQuery event, but here we are operating on native elements.

"input" is what fires when correcting a spelling mistake, and it has good compatibility across all decent browsers since IE9, so I'm fairly confident this is a safe change. https://caniuse.com/#feat=input-event

To test it out:

1) `npm install && ./bin/example-server`

2) Load up two browser windows pointing at http://localhost:8000/

3) Intentionally make a typo, eg "footbakk" (observing that the changes propagate to both clients up until this point)

4) In one window, right click the typo and correct it to "football"

5) On master this change will not propagate correctly, on this branch it will
