### PR TITLE
Configure dependabot for security updates

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,0 +1,13 @@
+version: 1
+
+update_configs:
+  - package_manger: "javascript"
+    directory: "/"
+    # How often to check for non-security updates and when to create pull
+    # requests. Security updates are always created as soon as possible.
+    update_schedule: "daily"
+    allowed_updates:
+      # Always allow security updates.
+      - match:
+          dependency_type: "all"
+          update_type: "security"


### PR DESCRIPTION
Same as https://github.com/conversation/tc/pull/9793:

We'd like to make sure we're staying on top of any important security
fixes in our dependencies. Github acquired dependabot last year and made
it free to use, which is useful since that can help us do exactly that.

This adds a dependabot config file that should result in automated PRs
providing security fixes for JS dependencies.