### PR TITLE
Switch from Travis CI to GitHub Actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,30 @@
+name: nodeunit tests
+on: [push]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    services:
+      redis:
+        image: redis
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 6379:6379
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: '16.x'
+      - run: |
+          sudo apt-get install postgresql libpq-dev
+          sudo service postgresql start
+          sudo -u postgres createuser --superuser runner
+          sudo -u postgres createdb sharejs_example
+      - run: npm install
+      - run: npm run test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,0 @@
-before_script: "npm install && npm install nodeunit@0.9.0 coffee-script@1.7.0"
-branches:
-  only:
-    - master
-language: node_js
-node_js:
-  - 8.11.1
-services:
-  - redis-server


### PR DESCRIPTION
Travis CI was still giving me that unknown error when I tried to set this repo up on the .com product, so might as well just use github actions considering it wasn't too difficult to set up.