### PR TITLE
Improve error logged when there's an exception applying ops

### DIFF
--- a/src/server/model.coffee
+++ b/src/server/model.coffee
@@ -138,7 +138,7 @@ module.exports = Model = (db, options) ->
       try
         snapshot = doc.type.apply doc.snapshot, opData.op
       catch error
-        console.error error.stack
+        console.error docName, error.stack
         return callback error.message
 
       # The op data should be at the current version, and the new document data should be at

--- a/src/types/json.coffee
+++ b/src/types/json.coffee
@@ -73,7 +73,8 @@ json.apply = (snapshot, op) ->
       else if c.sd != undefined
         # String delete
         throw new Error 'Referenced element not a string' unless typeof elem is 'string'
-        throw new Error 'Deleted string does not match' unless elem[key...key + c.sd.length] == c.sd
+        debugDeleteOp = "1: #{JSON.stringify elem[key...key + c.sd.length]} 2: #{JSON.stringify(c.sd)}"
+        throw new Error "Deleted string does not match (#{debugDeleteOp})" unless elem[key...key + c.sd.length] == c.sd
         parent[parentkey] = elem[...key] + elem[key + c.sd.length..]
 
       else if c.li != undefined && c.ld != undefined


### PR DESCRIPTION
We're still getting intermittent "Deleted string does not match" errors despite some of the other fixes applied, hoping that just logging the strings attempted to be deleted will reveal the problem.

To test (assuming starting from a blank slate):
```
npm install && npm run build
createdb sharejs_example
bin/sharejs
```

Now we need to create a json type document with a text type subdocument, insert a string, then give it a bad delete op:

Create a document
`curl -X PUT -H 'Content-Type: application/json' -d '{"type": "json"}' http://localhost:9000/doc/test`

Post an object insert op to insert an empty object to create a json document type
`curl -X POST -H 'Content-Type: application/json' -d '[{ "p": [], "oi": {} }]' http://localhost:9000/doc/test?v=0`

Object insert on the key "test", inserting an empty string to create a text subdocument within the json document
`curl -X POST -H 'Content-Type: application/json' -d '[{ "p": ["test"], "oi": "" }]' http://localhost:9000/doc/test?v=1`

String insert on the text subdocument
`curl -X POST -H 'Content-Type: application/json' -d '[{ "p": ["test", 0], "si": "foo bar" }]' http://localhost:9000/doc/test?v=2`

At this point do a GET on the document just to sanity check it's as expected:
`curl http://localhost:9000/doc/test`

Should return 
`{"test":"foo bar"}`

Now give it a bad delete operation to trigger the exception.

We want to delete from the last 'o' in foo to the 'a' in bar to send up with "for", but give it some bogus delete text
`curl -X POST -H 'Content-Type: application/json' -d '[{ "p": ["test", 2], "sd": "xxxx" }]' http://localhost:9000/doc/test?v=3`

This should raise an error
`test Error: Deleted string does not match (1: "o ba" 2: "xxxx")`

Now give it a properly formed delete op
`curl -X POST -H 'Content-Type: application/json' -d '[{ "p": ["test", 2], "sd": "o ba" }]' http://localhost:9000/doc/test?v=3`

GET the document again
`curl http://localhost:9000/doc/test`

The subdocument should only contain "for" 
`{"test":"for"}`
