### PR TITLE
Upgrade ws to 2.3.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "sockjs": ">= 0.3.1",
     "socket.io": "2.5.0",
     "socket.io-client": "2.4.0",
-    "ws": "0.4.32",
+    "ws": "2.3.1",
     "request": ">= 2.1.1",
     "coffee-script": "1.7.0",
     "hat": "*"


### PR DESCRIPTION
This doesn't get us anywhere near on the latest version, but this at least resolves some security issues with the ancient 0.4.32 version. 

Going to 3.x and beyond will need some code changes by the looks of it.