### PR TITLE
Fix stats track and inactive client reaping

### DIFF
--- a/src/server/websocket.coffee
+++ b/src/server/websocket.coffee
@@ -61,7 +61,7 @@ exports.attach = (server, createAgent, options) ->
   # event, the client would have already established a new connection by the time
   # the server terminates it from it's side.
   setInterval ->
-    for client in wss.clients
+    wss.clients.forEach (client) ->
       client.terminate() if !client.isAlive
       client.isAlive = false
   , CLIENT_TIMEOUT

--- a/src/server/websocket.coffee
+++ b/src/server/websocket.coffee
@@ -43,7 +43,7 @@ exports.attach = (server, createAgent, options) ->
   if !!options.trackStats
     setInterval ->
       options.trackStats
-        activeWebsocketConnections: wss.clients.length
+        activeWebsocketConnections: wss.clients.size
     , STATISTICS_INTERVAL
 
   # Clients send out a heartbeat at 10 second intervals, if


### PR DESCRIPTION
We picked up this issue because the stats were returning nothing, so out of caution we rolled back to and older version in production until I could look at this again.

Turns out the type of `wss.clients` [changed](https://github.com/websockets/ws/issues/934) from `Array` to `Set`, so while all the document editing and so on was working fine, our stats tracking and inactive client reaping was not. This fixes both of those issues so we should be good to proceed with the upgrade again.

![Screenshot at 2025-01-28 11-50-46](https://github.com/user-attachments/assets/4fb10527-db75-40e3-8195-395a4d2f68ba)

(note that I added some temporary logging to make it more obvious when an inactive connection was reaped)

To test, run the `bin/exampleserver` and visit http://localhost:8000/

You should see the stats tracking in the example server working correctly (it currently does not on master). 