### PR TITLE
Remove remnants of socket.io

### DIFF
--- a/bin/exampleserver
+++ b/bin/exampleserver
@@ -42,7 +42,7 @@ console.log("Options: ", options);
 
 var port = argv.p;
 
-// Attach the sharejs REST and Socket.io interfaces to the server
+// Attach the sharejs REST and websocket interfaces to the server
 var server = sharejs.server.attach(app, options);
 
 app.get('/pad/?', function(req, res, next) {

--- a/bin/sharejs
+++ b/bin/sharejs
@@ -17,7 +17,7 @@ options = require('./options') || {};
 
 console.log("ShareJS server v" + sharejs.version);
 
-// Attach the sharejs REST and Socket.io interfaces to the server
+// Attach the sharejs REST and websocket interfaces to the server
 var server = sharejs.server.attach(app, options);
 
 var port = options.port || 8000;

--- a/package.json
+++ b/package.json
@@ -17,8 +17,6 @@
     "pg": "7.4.0",
     "pg-native": "3.0.1",
     "sockjs": ">= 0.3.1",
-    "socket.io": "2.5.0",
-    "socket.io-client": "2.4.0",
     "ws": "5.2.4",
     "request": ">= 2.1.1",
     "coffee-script": "1.7.0",

--- a/src/client/doc.coffee
+++ b/src/client/doc.coffee
@@ -231,8 +231,7 @@ class Doc
         # We got a new op from the server.
         # msg is {doc:, op:, v:}
 
-        # There is a bug in socket.io (produced on firefox 3.6) which causes messages
-        # to be duplicated sometimes.
+        # There is a bug which causes messages to be duplicated sometimes.
         # We'll just silently drop subsequent messages.
         return if msg.v < @version
 

--- a/src/client/index.coffee
+++ b/src/client/index.coffee
@@ -4,9 +4,6 @@
 # It works from both a node.js context and a web context (though in the latter case,
 # it needs to be compiled to work.)
 #
-# It should become a little nicer once I start using more of the new RPC features added
-# in socket.io 0.7.
-#
 # Note that anything declared in the global scope here is shared with other files
 # built by closure. Be careful what you put in this namespace.
 

--- a/src/server/useragent.coffee
+++ b/src/server/useragent.coffee
@@ -28,11 +28,6 @@ module.exports = (model, options) ->
       # Should be manually set by the auth function.
       @name = null
 
-      # We have access to these with socket.io, but I'm not sure we can support
-      # these properties on the REST API or sockjs, etc.
-      #xdomain: data.xdomain
-      #secure: data.secure
-
     # This is a helper method which wraps auth() above. It creates the action and calls
     # auth. If authentication succeeds, acceptCallback() is called if it exists. otherwise
     # userCallback(true) is called.

--- a/test/helpers/webclient.coffee
+++ b/test/helpers/webclient.coffee
@@ -10,7 +10,6 @@ TEST_UNCOMPRESSED = false
 fs = require 'fs'
 
 window = {}
-window.io = require 'socket.io-client'
 
 for script in ['share', 'json']
   script = "#{script}.uncompressed" if TEST_UNCOMPRESSED

--- a/test/integration.coffee
+++ b/test/integration.coffee
@@ -105,8 +105,7 @@ genTests = (client, dbType) -> testCase
           # This test consumes open file handles. If you want to set
           # it higher, you need to run:
           #  % ulimit -n 8096
-          # to increase the OS limit. This happens because of a bug in
-          # socket.io.
+          # to increase the OS limit.
           if num < 30
             nowOrLater more
           else

--- a/test/server.coffee
+++ b/test/server.coffee
@@ -22,6 +22,6 @@ testRunning = (url, port, callback) ->
   post.end '{"type":"simple"}'
   
   
-  # Also, open the DB using socket.io and make a document
+  # Open the DB and make a document
   client = new client.Connection 'localhost', port, url
   client.

--- a/test/sockjs.coffee
+++ b/test/sockjs.coffee
@@ -379,10 +379,6 @@ module.exports = testCase
 
         test.strictEqual typeof agent.headers, 'object'
 
-        # I can't edit the headers using socket.io-agent's API. I'd test the default headers in this
-        # object, but the default XHR headers aren't part of socket.io's API, so they could change between
-        # versions and break the test.
-
         # TODO - Get SockJS to put user-agent header in the connection
         test.strictEqual agent.headers['user-agent'], undefined #'node.js'
 

--- a/tests.coffee
+++ b/tests.coffee
@@ -36,8 +36,10 @@ modules = [
 
 exports[module] = require "./test/#{module}" for module in modules
 
-# This is a little hack to get around the lack of cleanup done by socket.io. It should terminate
+# This is a little hack to get around the lack of cleanup done by sockjs. It should terminate
 # the node.js process 2 seconds after all the tests are complete.
+#
+# When sockjs is removed, this can be removed as well
 exports.cleanup = (test) ->
   test.done()
   setTimeout (-> process.exit(0)), 2000


### PR DESCRIPTION
We had actually stopped using it a while back, so this doesn't change much other than removing the packages and cleaning up some irrelevant comments.

Can boot up `./bin/exampleserver` to sanity check if you'd like.