### PR TITLE
Upgrade sockjs to 0.3.24

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "express": "^4.8.0",
     "pg": "7.4.0",
     "pg-native": "3.0.1",
-    "sockjs": ">= 0.3.1",
+    "sockjs": "0.3.24",
     "ws": "5.2.4",
     "coffee-script": "1.7.0",
     "hat": "*"


### PR DESCRIPTION
We technically don't use this, but it has some value in supporting tests that have not been ported to websocket yet.

Nothing to test manually, covered by automated tests.