### PR TITLE
Upgrade pg to 8.16.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "author": "Joseph Gentle <josephg@gmail.com>",
   "dependencies": {
     "express": "^4.8.0",
-    "pg": "7.4.0",
+    "pg": "^8.16.0",
     "pg-native": "3.0.1",
     "sockjs": "0.3.24",
     "ws": "5.2.4",


### PR DESCRIPTION
Covered by tests so no need for manual check. 

This is just to allow us to dedupe some packages and upgrade `semver` in another repo.