### PR TITLE
Change the versions API to always return ALL operations

### DIFF
--- a/src/server/model.coffee
+++ b/src/server/model.coffee
@@ -513,6 +513,7 @@ module.exports = Model = (db, options) ->
 
         buildVersions = (callback, ops, results = []) ->
           if ops.length
+            lastOpV = ops[ops.length - 1].v
             versionOps = ops.slice(0, opBatchAmount)
 
             try
@@ -521,7 +522,7 @@ module.exports = Model = (db, options) ->
                 docTemplate.snapshot = type.apply(docTemplate.snapshot, op.op)
                 docTemplate.meta = op.meta
 
-                if docTemplate.v % n is 0
+                if docTemplate.v % n is 0 or op.v is lastOpV
                   results.push({
                     v: docTemplate.v,
                     type: docTemplate.type.name,

--- a/test/rest.coffee
+++ b/test/rest.coffee
@@ -7,7 +7,7 @@ express = require 'express'
 server = require '../src/server'
 types = require '../src/types'
 
-{makePassPart, newDocName, fetch} = require './helpers'
+{applyOps, makePassPart, newDocName, fetch} = require './helpers'
 
 # Frontend tests
 module.exports = testCase
@@ -83,6 +83,51 @@ module.exports = testCase
           test.strictEqual headers['content-type'], 'text/plain'
           test.deepEqual data, 'hi'
           test.done()
+
+  'GET /doc/:name/versions returns [] for a document with no ops': (test) ->
+    @model.create @name, 'simple', =>
+      fetch 'GET', @port, "/doc/#{@name}/versions", null, (res, data, headers) ->
+        test.strictEqual res.statusCode, 200
+        test.strictEqual headers['content-type'], 'application/json'
+        test.deepEqual data, []
+        test.done()
+
+  'GET /doc/:name/versions returns the list of applied ops': (test) ->
+    @model.create @name, 'text', =>
+      applyOps @model, @name, 0, [
+          [{p: 0, i: 'h'}]
+          [{p: 1, i: 'i'}]
+          [{p: 2, i: ' '}]
+          [{p: 3, i: 't'}]
+          [{p: 4, i: 'h'}]
+          [{p: 5, i: 'i'}]
+          [{p: 6, i: 's'}]
+          [{p: 7, i: ' '}]
+          [{p: 8, i: 'i'}]
+          [{p: 9, i: 's'}]
+          [{p: 10, i: ' '}]
+          [{p: 11, i: 'd'}]
+          [{p: 12, i: 'o'}]
+          [{p: 13, i: 'g'}]
+        ], (error, data) =>
+          test.strictEqual error, null
+
+          fetch 'GET', @port, "/doc/#{@name}/versions?every=10", null, (res, data, headers) ->
+            test.strictEqual res.statusCode, 200
+            test.strictEqual headers['content-type'], 'application/json'
+
+            version1 = data[0]
+            version2 = data[1]
+
+            test.strictEqual version1.v, 10
+            test.strictEqual version1.type, 'text'
+            test.strictEqual version1.snapshot, 'hi this is'
+
+            test.strictEqual version2.v, 14
+            test.strictEqual version2.type, 'text'
+            test.strictEqual version2.snapshot, 'hi this is dog'
+
+            test.done()
 
   'PUT a document creates it': (test) ->
     fetch 'PUT', @port, "/doc/#{@name}", {type:'simple'}, (res, data) =>


### PR DESCRIPTION
Previously, if there were not enough ops to "fill" an entire version, they would not be included in the returned array, now the incomplete version is included in the results.

This does mean each version is no longer guaranteed to return the same result every time, but in practice this shouldn't be an issue with how we use this API.

To test, start up the demo server:
```
./bin/demoserver
```

Open the demo app in your browser: http://localhost:8000/

Add enough text to make one full version, and one partial version, with versions grouped every 10 ops, eg:
```
yo this is dog
```

curl the versions api, you should now see two versions returned:
```
curl http://localhost:8000/doc/blag/versions?every=10 | jq
```

```json
[
  {
    "v": 10,
    "type": "text",
    "snapshot": "yo this is",
    "meta": {
      "source": "2d3f398f8bb6b1a2fba14ff2ae0867b6",
      "ts": 1762920066706
    }
  },
  {
    "v": 14,
    "type": "text",
    "snapshot": "yo this is dog",
    "meta": {
      "source": "2d3f398f8bb6b1a2fba14ff2ae0867b6",
      "ts": 1762920067193
    }
  }
]

```